### PR TITLE
Docker build uses configurable `FETCH_VERSION`.

### DIFF
--- a/amd64/Dockerfile
+++ b/amd64/Dockerfile
@@ -28,14 +28,11 @@
 #
 # References:
 #  - Follow platform guideline specified in https://github.com/docker-library/official-images
-# 
+#
 
 FROM ubuntu:20.04
 
-LABEL maintainer "somsakc@hotmail.com"
-LABEL version="1.5"
-LABEL description="Docker container for Observium Community Edition"
-
+ARG FETCH_VERSION=latest
 ARG OBSERVIUM_ADMIN_USER=admin
 ARG OBSERVIUM_ADMIN_PASS=passw0rd
 ARG OBSERVIUM_DB_HOST=observiumdb
@@ -43,9 +40,15 @@ ARG OBSERVIUM_DB_USER=observium
 ARG OBSERVIUM_DB_PASS=passw0rd
 ARG OBSERVIUM_DB_NAME=observium
 
+LABEL maintainer "somsakc@hotmail.com"
+LABEL version="1.5"
+LABEL description="Docker container for Observium Community Edition"
+LABEL fetch_version="$FETCH_VERSION"
+
 # set environment variables
-ENV LANG en_US.UTF-8
-ENV LANGUAGE en_US.UTF-8
+ENV FETCH_VERSION=$FETCH_VERSION
+ENV LANG=en_US.UTF-8
+ENV LANGUAGE=$LANG
 ENV OBSERVIUM_DB_HOST=$OBSERVIUM_DB_HOST
 ENV OBSERVIUM_DB_USER=$OBSERVIUM_DB_USER
 ENV OBSERVIUM_DB_PASS=$OBSERVIUM_DB_PASS
@@ -73,14 +76,11 @@ RUN apt-get update && \
     mkdir /var/log/apache2
 
 # set locale
-RUN locale-gen en_US.UTF-8
+RUN locale-gen $LANG
 
 # install observium package
 RUN mkdir -p /opt/observium /opt/observium/logs /opt/observium/rrd && \
-    cd /opt && \
-    wget http://www.observium.org/observium-community-latest.tar.gz && \
-    tar zxvf observium-community-latest.tar.gz && \
-    rm -f observium-community-latest.tar.gz
+    wget -qO - http://www.observium.org/observium-community-${FETCH_VERSION}.tar.gz | tar -zxvf - -C /opt
 
 # configure observium package
 RUN cd /opt/observium && \
@@ -96,10 +96,8 @@ COPY observium-init.sh /opt/observium/observium-init.sh
 RUN chmod a+x /opt/observium/observium-init.sh && \
     chown -R www-data:www-data /opt/observium
 
-# check version and installed files
-RUN [ -f /opt/observium/VERSION ] && cat /opt/observium/VERSION
-#RUN [ -f /opt/observium/VERSION ] && cat /opt/observium/VERSION && \
-#    find /opt -ls
+# check version
+RUN [ -f /opt/observium/VERSION ] && echo VERSION=$(cat /opt/observium/VERSION)
 
 # configure php modules
 RUN phpenmod mcrypt

--- a/amd64/docker-compose.yml
+++ b/amd64/docker-compose.yml
@@ -19,13 +19,22 @@ services:
     restart: always
 
   app:
-    image: mbixtech/observium:22.5
+    # Launch published image.
+    image: mbixtech/observium:latest
+
+    # Or build image.
+    # build:
+    #   args:
+    #     # Build specific version or "latest".
+    #     # - FETCH_VERSION=22.12
+    #     - FETCH_VERSION=latest
+
     environment:
       - OBSERVIUM_ADMIN_USER=admin
       - OBSERVIUM_ADMIN_PASS=passw0rd
       - OBSERVIUM_DB_HOST=db
       - OBSERVIUM_DB_NAME=observium
-      - OBSERVIUM_DB_USER=observium 
+      - OBSERVIUM_DB_USER=observium
       - OBSERVIUM_DB_PASS=passw0rd
       - OBSERVIUM_BASE_URL=http://observium.mbixtech.com:8888
       - TZ=Asia/Bangkok
@@ -42,4 +51,4 @@ services:
 
 networks:
   back-tier:
-      driver: bridge
+    driver: bridge

--- a/amd64/observium-apache24
+++ b/amd64/observium-apache24
@@ -2,17 +2,17 @@
     ServerAdmin webmaster@localhost
     DocumentRoot /opt/observium/html
     <FilesMatch \.php$>
-      SetHandler application/x-httpd-php
+        SetHandler application/x-httpd-php
     </FilesMatch>
     <Directory />
-            Options FollowSymLinks
-            AllowOverride None
+        Options FollowSymLinks
+        AllowOverride None
     </Directory>
     <Directory /opt/observium/html/>
-            DirectoryIndex index.php
-            Options Indexes FollowSymLinks MultiViews
-            AllowOverride All
-            Require all granted
+        DirectoryIndex index.php
+        Options Indexes FollowSymLinks MultiViews
+        AllowOverride All
+        Require all granted
     </Directory>
     ErrorLog /opt/observium/logs/apache2-error.log
     LogLevel warn

--- a/arm32v7/Dockerfile
+++ b/arm32v7/Dockerfile
@@ -28,14 +28,11 @@
 #
 # References:
 #  - Follow platform guideline specified in https://github.com/docker-library/official-images
-# 
+#
 
 FROM ubuntu:16.04
 
-LABEL maintainer "somsakc@hotmail.com"
-LABEL version="1.3"
-LABEL description="Docker container for Observium Community Edition"
-
+ARG FETCH_VERSION=latest
 ARG OBSERVIUM_ADMIN_USER=admin
 ARG OBSERVIUM_ADMIN_PASS=passw0rd
 ARG OBSERVIUM_DB_HOST=observiumdb
@@ -43,9 +40,15 @@ ARG OBSERVIUM_DB_USER=observium
 ARG OBSERVIUM_DB_PASS=passw0rd
 ARG OBSERVIUM_DB_NAME=observium
 
+LABEL maintainer "somsakc@hotmail.com"
+LABEL version="1.3"
+LABEL description="Docker container for Observium Community Edition"
+LABEL fetch_version="$FETCH_VERSION"
+
 # set environment variables
-ENV LANG en_US.UTF-8
-ENV LANGUAGE en_US.UTF-8
+ENV FETCH_VERSION=$FETCH_VERSION
+ENV LANG=en_US.UTF-8
+ENV LANGUAGE=$LANG
 ENV OBSERVIUM_DB_HOST=$OBSERVIUM_DB_HOST
 ENV OBSERVIUM_DB_USER=$OBSERVIUM_DB_USER
 ENV OBSERVIUM_DB_PASS=$OBSERVIUM_DB_PASS
@@ -71,14 +74,11 @@ RUN apt-get update && \
     mkdir /var/log/apache2
 
 # set locale
-RUN locale-gen en_US.UTF-8
+RUN locale-gen $LANG
 
 # install observium package
 RUN mkdir -p /opt/observium /opt/observium/logs /opt/observium/rrd && \
-    cd /opt && \
-    wget http://www.observium.org/observium-community-latest.tar.gz && \
-    tar zxvf observium-community-latest.tar.gz && \
-    rm -f observium-community-latest.tar.gz
+    wget -qO - http://www.observium.org/observium-community-${FETCH_VERSION}.tar.gz | tar -zxvf - -C /opt
 
 # configure observium package
 RUN cd /opt/observium && \
@@ -94,9 +94,8 @@ COPY observium-init.sh /opt/observium/observium-init.sh
 RUN chmod a+x /opt/observium/observium-init.sh && \
     chown -R www-data:www-data /opt/observium
 
-# check version and installed files
-RUN [ -f /opt/observium/VERSION ] && cat /opt/observium/VERSION && \
-    find /opt -ls
+# check version
+RUN [ -f /opt/observium/VERSION ] && echo VERSION=$(cat /opt/observium/VERSION)
 
 # configure php modules
 RUN phpenmod mcrypt

--- a/arm32v7/docker-compose.yml
+++ b/arm32v7/docker-compose.yml
@@ -5,41 +5,50 @@ version: '3'
 
 services:
   observiumdb:
-       image: jsurf/rpi-mariadb:latest
-       environment:
-         - MYSQL_ROOT_PASSWORD=passw0rd
-         - MYSQL_USER=observium
-         - MYSQL_PASSWORD=passw0rd
-         - MYSQL_DATABASE=observium
-         - TZ=Asia/Bangkok
-       volumes:
-         - ./data:/var/lib/mysql
-       networks:
-         - back-tier
-       restart: always
+    image: jsurf/rpi-mariadb:latest
+    environment:
+      - MYSQL_ROOT_PASSWORD=passw0rd
+      - MYSQL_USER=observium
+      - MYSQL_PASSWORD=passw0rd
+      - MYSQL_DATABASE=observium
+      - TZ=Asia/Bangkok
+    volumes:
+      - ./data:/var/lib/mysql
+    networks:
+      - back-tier
+    restart: always
 
   observiumap:
-       image: mbixtech/arm32v7-observium:latest
-       environment:
-         - OBSERVIUM_ADMIN_USER=admin
-         - OBSERVIUM_ADMIN_PASS=passw0rd
-         - OBSERVIUM_DB_HOST=observiumdb
-         - OBSERVIUM_DB_NAME=observium
-         - OBSERVIUM_DB_USER=observium 
-         - OBSERVIUM_DB_PASS=passw0rd
-         - OBSERVIUM_BASE_URL=http://observium-rpi.mbixtech.com:8888
-         - TZ=Asia/Bangkok
-       volumes:
-         - ./logs:/opt/observium/logs
-         - ./rrd:/opt/observium/rrd
-       networks:
-         - back-tier
-       ports:
-         - "8888:80"
-       restart: always
-       depends_on:
-         - observiumdb
+    # Launch published image.
+    image: mbixtech/arm32v7-observium:latest
+
+    # Or build image.
+    # build:
+    #   args:
+    #     # Build specific version or "latest".
+    #     # - FETCH_VERSION=22.12
+    #     - FETCH_VERSION=latest
+
+    environment:
+      - OBSERVIUM_ADMIN_USER=admin
+      - OBSERVIUM_ADMIN_PASS=passw0rd
+      - OBSERVIUM_DB_HOST=observiumdb
+      - OBSERVIUM_DB_NAME=observium
+      - OBSERVIUM_DB_USER=observium
+      - OBSERVIUM_DB_PASS=passw0rd
+      - OBSERVIUM_BASE_URL=http://observium-rpi.mbixtech.com:8888
+      - TZ=Asia/Bangkok
+    volumes:
+      - ./logs:/opt/observium/logs
+      - ./rrd:/opt/observium/rrd
+    networks:
+      - back-tier
+    ports:
+      - "8888:80"
+    restart: always
+    depends_on:
+      - observiumdb
 
 networks:
   back-tier:
-      driver: bridge
+    driver: bridge

--- a/arm32v7/observium-apache24
+++ b/arm32v7/observium-apache24
@@ -2,17 +2,17 @@
     ServerAdmin webmaster@localhost
     DocumentRoot /opt/observium/html
     <FilesMatch \.php$>
-      SetHandler application/x-httpd-php
+        SetHandler application/x-httpd-php
     </FilesMatch>
     <Directory />
-            Options FollowSymLinks
-            AllowOverride None
+        Options FollowSymLinks
+        AllowOverride None
     </Directory>
     <Directory /opt/observium/html/>
-            DirectoryIndex index.php
-            Options Indexes FollowSymLinks MultiViews
-            AllowOverride All
-            Require all granted
+        DirectoryIndex index.php
+        Options Indexes FollowSymLinks MultiViews
+        AllowOverride All
+        Require all granted
     </Directory>
     ErrorLog /opt/observium/logs/apache2-error.log
     LogLevel warn

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,7 @@ services:
       - OBSERVIUM_ADMIN_PASS=passw0rd
       - OBSERVIUM_DB_HOST=db
       - OBSERVIUM_DB_NAME=observium
-      - OBSERVIUM_DB_USER=observium 
+      - OBSERVIUM_DB_USER=observium
       - OBSERVIUM_DB_PASS=passw0rd
       - OBSERVIUM_BASE_URL=http://observium.mbixtech.com:8888
       - TZ=Asia/Bangkok


### PR DESCRIPTION
Build specific versions instead of "latest" by providing an optional `FETCH_VERSION` build arg.

```sh
cd amd64

# Build latest.
docker build -t observium .

# Build 22.12.
docker build -t observium:22.12 --build-arg FETCH_VERSION=22.12 .
```

`FETCH_VERSION` may be any version tagged on the published tarball at:
`http://www.observium.org/observium-community-${FETCH_VERSION}.tar.gz`

Included some config tidy on incorrect indentation.

Closes #29