### PR TITLE
Ubuntu 22.04+observium ce

### DIFF
--- a/amd64/Dockerfile
+++ b/amd64/Dockerfile
@@ -79,6 +79,8 @@ RUN apt install -y  libapache2-mod-php8.1 \
                     php8.1-curl \
                     php-apcu \
                     php-pear \
+                    libphp-phpmailer \
+                    libvirt-clients \
                     snmp \
                     fping \
                     mysql-client \

--- a/amd64/Dockerfile
+++ b/amd64/Dockerfile
@@ -1,6 +1,6 @@
 # Docker container for Observium Community Edition
 #
-# It requires option of e.g. '--link observiumdb:observiumdb' with another MySQL or MariaDB container.
+# Requires a linked MySQL or MariaDB container (ex.: `--link observiumdb:observiumdb`)
 # Example usage:
 # 1. MySQL or MariaDB container
 #    $ mkdir -p /home/docker/observium/data
@@ -30,7 +30,7 @@
 #  - Follow platform guideline specified in https://github.com/docker-library/official-images
 #
 
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 ARG FETCH_VERSION=latest
 ARG OBSERVIUM_ADMIN_USER=admin
@@ -41,7 +41,7 @@ ARG OBSERVIUM_DB_PASS=passw0rd
 ARG OBSERVIUM_DB_NAME=observium
 
 LABEL maintainer "somsakc@hotmail.com"
-LABEL version="1.6"
+LABEL version="1.7"
 LABEL description="Docker container for Observium Community Edition"
 LABEL fetch_version="$FETCH_VERSION"
 
@@ -49,20 +49,53 @@ LABEL fetch_version="$FETCH_VERSION"
 ENV FETCH_VERSION=$FETCH_VERSION
 ENV LANG=en_US.UTF-8
 ENV LANGUAGE=$LANG
+ENV OBSERVIUM_DIR="/opt/observium"
 ENV OBSERVIUM_DB_HOST=$OBSERVIUM_DB_HOST
 ENV OBSERVIUM_DB_USER=$OBSERVIUM_DB_USER
 ENV OBSERVIUM_DB_PASS=$OBSERVIUM_DB_PASS
 ENV OBSERVIUM_DB_NAME=$OBSERVIUM_DB_NAME
 
-# install prerequisites and cleanup
-RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections && \
-    apt-get update && \
-    apt-get install -y libapache2-mod-php7.4 php7.4-cli php7.4-mysql php7.4-mysqli php7.4-gd php7.4-json php-pear snmp fping mysql-client python3-mysqldb rrdtool subversion whois mtr-tiny ipmitool graphviz imagemagick apache2 python3-pymysql python-is-python3 monitoring-plugins-basic monitoring-plugins-common monitoring-plugins-standard && \
-    apt-get install -y libvirt-clients && \
-    apt-get install -y libphp-phpmailer && \
-    apt-get install -y cron curl locales supervisor wget && \
-    apt-get install -y logrotate && \
-    apt-get clean && \
+# ensure apt will not ask for things interactively
+ARG DEBIAN_FRONTEND=noninteractive
+
+# update & install base packages
+RUN apt update && \
+    apt upgrade -y && \
+    apt install -y  cron \
+                    locales \
+                    supervisor \
+                    logrotate \
+                    curl \
+                    wget
+
+# install observium required packages
+RUN apt install -y  libapache2-mod-php8.1 \
+                    php8.1-cli \
+                    php8.1-mysql \
+                    php8.1-gd \
+                    php8.1-bcmath \
+                    php8.1-mbstring \
+                    php8.1-opcache \
+                    php8.1-curl \
+                    php-apcu \
+                    php-pear \
+                    snmp \
+                    fping \
+                    mysql-client \
+                    rrdtool \
+                    subversion \
+                    whois \
+                    mtr-tiny \
+                    ipmitool \
+                    graphviz \
+                    imagemagick \
+                    apache2 \
+                    python3-mysqldb \
+                    python3-pymysql \
+                    python-is-python3
+
+# cleanup
+RUN apt clean && \
     rm -f /etc/apache2/sites-available/* && \
     rm -f /etc/cron.d/* && \
     rm -f /etc/cron.hourly/* && \
@@ -78,38 +111,36 @@ RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selectio
 # set locale
 RUN locale-gen $LANG
 
-# install observium package
+# install observium
 RUN mkdir -p /opt/observium /opt/observium/logs /opt/observium/rrd && \
-    wget -qO - http://www.observium.org/observium-community-${FETCH_VERSION}.tar.gz | tar -zxvf - -C /opt
+    chmod 755 /opt/observium /opt/observium/logs /opt/observium/rrd && \
+    wget -qO - http://www.observium.org/observium-community-${FETCH_VERSION}.tar.gz | \
+    tar -zxvf - -C /opt
 
-# configure observium package
-RUN cd /opt/observium && \
-    cp config.php.default config.php && \
-    sed -i -e "s/= 'localhost';/= getenv('OBSERVIUM_DB_HOST');/g" config.php && \
-    sed -i -e "s/= 'USERNAME';/= getenv('OBSERVIUM_DB_USER');/g" config.php && \
-    sed -i -e "s/= 'PASSWORD';/= getenv('OBSERVIUM_DB_PASS');/g" config.php && \
-    sed -i -e "s/= 'observium';/= getenv('OBSERVIUM_DB_NAME');/g" config.php && \
-    echo "\$config['base_url'] = getenv('OBSERVIUM_BASE_URL');" >> config.php
+# configure observium
+RUN sed -e "s/= 'localhost';/= getenv('OBSERVIUM_DB_HOST');/g" \
+        -e "s/= 'USERNAME';/= getenv('OBSERVIUM_DB_USER');/g"  \
+        -e "s/= 'PASSWORD';/= getenv('OBSERVIUM_DB_PASS');/g"  \
+        -e "s/= 'observium';/= getenv('OBSERVIUM_DB_NAME');/g" \
+        -e "$ a \$config['base_url'] = getenv('OBSERVIUM_BASE_URL');" \
+        /opt/observium/config.php.default > /opt/observium/config.php
 
 COPY observium-init.sh /opt/observium/observium-init.sh
 
 RUN chmod a+x /opt/observium/observium-init.sh && \
     chown -R www-data:www-data /opt/observium
 
-# check version
-RUN [ -f /opt/observium/VERSION ] && echo VERSION=$(cat /opt/observium/VERSION)
-
 # configure php modules
 RUN phpenmod mcrypt
 
-# configure apache configuration and modules
+# setup apache configuration and modules
 COPY observium-apache24 /etc/apache2/sites-available/000-default.conf
 RUN a2dismod mpm_event && \
     a2enmod mpm_prefork && \
-    a2enmod php7.4 && \
+    a2enmod php8.1 && \
     a2enmod rewrite && \
     chmod 644 /etc/apache2/sites-available/000-default.conf && \
-    sed -i -e "s/\${APACHE_LOG_DIR}\//\/opt\/observium\/logs\/apache2-/g" /etc/apache2/apache2.conf
+    sed -i -e 's#${APACHE_LOG_DIR}/#/opt/observium/logs/apache2-#g' /etc/apache2/apache2.conf
 
 # configure cron and logrotate
 COPY logrotate-conf /etc/logrotate.conf
@@ -129,4 +160,3 @@ EXPOSE 80/tcp
 
 # set volumes
 VOLUME ["/opt/observium/logs","/opt/observium/rrd"]
-

--- a/amd64/observium-init.sh
+++ b/amd64/observium-init.sh
@@ -1,52 +1,59 @@
 #!/usr/bin/env bash
 
-count=0
-rc=1
+function WriteLog() {
+  echo "$(date +%Y-%m-%d\ %H:%M:%S) [$(basename ${0})] ${1}"
+  return 0
+}
 
-while [ $rc -ne 0 ]
-do
-   let count++
-   echo "[$count] Verifying coonection to observium database."
-   MYSQL_PWD="$OBSERVIUM_DB_PASS" mysql -h $OBSERVIUM_DB_HOST -u $OBSERVIUM_DB_USER -e "select 1" $OBSERVIUM_DB_NAME >/dev/null
-   rc=$?
-   [ $rc -ne 0 ] && sleep 5
-done
-
-echo "Connected to observium database successfully."
-
-tables=`MYSQL_PWD="$OBSERVIUM_DB_PASS" mysql -h $OBSERVIUM_DB_HOST -u $OBSERVIUM_DB_USER -e "show tables" $OBSERVIUM_DB_NAME 2>/dev/null`
-
-if [ -z "$tables" ]
-then
-   echo "Setting /opt/observium/rrd directory to www-data:www-data."
-   chown -v www-data:www-data /opt/observium/rrd
-   echo "Initializing database schema in first time running for observium."
-   /opt/observium/discovery.php -u
-   /opt/observium/adduser.php $OBSERVIUM_ADMIN_USER $OBSERVIUM_ADMIN_PASS 10
-else
-  echo "Database schema initialization has been done already."
-  sleep 5
-fi
-
-if [ -z "$TZ" -o "$TZ" = "Etc/UTC" ]
-then
-   echo "Keep system timezone as the default of `cat /etc/timezone`."
-else
-   if [ -f /usr/share/zoneinfo/$TZ ]
-   then
-      echo "Setting system timezone to specific $TZ."
-      echo "$TZ" > /etc/timezone
-      ln -sfv /usr/share/zoneinfo/$TZ /etc/localtime
+# dynamically enforce timezone in container
+if [ -n "${TZ}" ]; then
+   WriteLog "Set timezone to '${TZ}'"
+   if [ -f "/usr/share/zoneinfo/${TZ}" ]; then
+      echo "${TZ}" > /etc/timezone
+      ln -sf /usr/share/zoneinfo/America/Toronto /etc/localtime
    else
-      echo "Invalid specific $TZ timezone and use the default of `cat /etc/timezone` instead."
+      WriteLog "Invalid specific $TZ timezone and use the default of `cat /etc/timezone` instead."
    fi
 fi
 
-echo "export OBSERVIUM_ADMIN_USER=$OBSERVIUM_ADMIN_USER" >> /opt/observium/observium-setenv.sh
-echo "export OBSERVIUM_ADMIN_PASS=$OBSERVIUM_ADMIN_PASS" >> /opt/observium/observium-setenv.sh
-echo "export OBSERVIUM_DB_HOST=$OBSERVIUM_DB_HOST" >> /opt/observium/observium-setenv.sh
-echo "export OBSERVIUM_DB_USER=$OBSERVIUM_DB_USER" >> /opt/observium/observium-setenv.sh
-echo "export OBSERVIUM_DB_PASS=$OBSERVIUM_DB_PASS" >> /opt/observium/observium-setenv.sh
-echo "export OBSERVIUM_DB_NAME=$OBSERVIUM_DB_NAME" >> /opt/observium/observium-setenv.sh
+count=0
+while true
+do
+   let count++
+   WriteLog "Check connection to observium database (attempt #${count})"
+   MYSQL_PWD="${OBSERVIUM_DB_PASS}" mysql \
+      --host="${OBSERVIUM_DB_HOST}" \
+      --user="${OBSERVIUM_DB_USER}" \
+      --execute="select 1" \
+      "${OBSERVIUM_DB_NAME}" >/dev/null && break
+   sleep 5
+done
+WriteLog "Connection to observium database checked after ${count} attempts"
+
+# ensure rrd data is always accessible
+WriteLog "Set /opt/observium/rrd directory to www-data:www-data"
+chown -R www-data:www-data "/opt/observium/rrd"
+
+# On first run create the default schema
+# Otherwise ensure the schema is up to date with the code
+WriteLog "Init/Update database schema"
+/opt/observium/discovery.php -u
+
+# ensure the admin user is always defined
+WriteLog "Add admin user"
+/opt/observium/adduser.php "${OBSERVIUM_ADMIN_USER}" "${OBSERVIUM_ADMIN_PASS}" 10
+
+# create a reusable environment for cronjobs
+WriteLog "Build environment script for cronjobs"
+(
+   echo "export OBSERVIUM_ADMIN_USER=${OBSERVIUM_ADMIN_USER}"
+   echo "export OBSERVIUM_ADMIN_PASS=${OBSERVIUM_ADMIN_PASS}"
+   echo "export OBSERVIUM_DB_HOST=${OBSERVIUM_DB_HOST}"
+   echo "export OBSERVIUM_DB_USER=${OBSERVIUM_DB_USER}"
+   echo "export OBSERVIUM_DB_PASS=${OBSERVIUM_DB_PASS}"
+   echo "export OBSERVIUM_DB_NAME=${OBSERVIUM_DB_NAME}"
+   echo "export OBSERVIUM_BASE_URL=${OBSERVIUM_BASE_URL}"
+) > "/opt/observium/observium-setenv.sh"
+chmod 750 "/opt/observium/observium-setenv.sh"
 
 exit 0

--- a/amd64/supervisord.conf
+++ b/amd64/supervisord.conf
@@ -1,4 +1,5 @@
 [supervisord]
+user=root
 pidfile=/var/run/supervisord.pid
 logfile=/dev/null
 logfile_backups=0


### PR DESCRIPTION
These changes update the base image to Ubuntu 22.04 and cleanup the process.  
I removed a couple of packages that are not needed in the context of a container (libvirt) and the community edition (monitoring plugins are useless unless you have a paid version of Observium).  
I also changed the bash script a bit, partly for cosmetic reasons and partly to achieve idempotence on restarts and upgrades.
