### PR TITLE
Fix observium init tz

### DIFF
--- a/amd64/observium-init.sh
+++ b/amd64/observium-init.sh
@@ -10,7 +10,7 @@ if [ -n "${TZ}" ]; then
    WriteLog "Set timezone to '${TZ}'"
    if [ -f "/usr/share/zoneinfo/${TZ}" ]; then
       echo "${TZ}" > /etc/timezone
-      ln -sf /usr/share/zoneinfo/America/Toronto /etc/localtime
+      ln -sf "/usr/share/zoneinfo/${TZ}" /etc/localtime
    else
       WriteLog "Invalid specific $TZ timezone and use the default of `cat /etc/timezone` instead."
    fi


### PR DESCRIPTION
Fix oversight in observium-init.sh script when setting the timezone (TZ).
