### PR TITLE
Upgrade Dockerfile to support Observium 24.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,34 @@
-# Docker container for Observium Community Edition
+# Docker Container for Observium Community Edition
 Observium is network monitoring with intuition. It is a low-maintenance auto-discovering network monitoring platform supporting a wide range of device types, platforms and operating systems including Cisco, Windows, Linux, HP, Juniper, Dell, FreeBSD, Brocade, Netscaler, NetApp and many more. Observium focuses on providing a beautiful and powerful yet simple and intuitive interface to the health and status of your network. For more information, go to http://www.observium.org site.
 
-Available platform are:-
+Available platforms are:
 * AMD64 (Intel x86_64) https://hub.docker.com/r/mbixtech/observium/
 * ARM32v7 (Raspberri Pi 2/3) https://hub.docker.com/r/mbixtech/arm32v7-observium/
 
-## Usage
+## Build Image
+### For amd64 Architecture
+```sh
+   $ cd amd64
+   $ docker build -t mbixtech/observium:latest .
+```
+- To build a specific version, add `--build-arg FETCH_VERSION=24.12`.
+
+### For arm32v7 Architecture
+```sh
+  $ cd arm32v7
+  $ docker build -t mbixtech/arm32v7-observium:latest .
+```
+
+## Launch Observium
 Either follow the choice A. or B. below to run Observium.
 
 ### A. Manual Run Containers
 - Prepare working directory for docker containers, for example below.
-```
+```sh
   $ mkdir -p /home/docker/observium/{data,logs,rrd}
 ```
 - Run official MariaDB container
-```
+```sh
   $ docker run --name observiumdb \
     -v /home/docker/observium/data:/var/lib/mysql \
     -e MYSQL_ROOT_PASSWORD=passw0rd \
@@ -26,7 +40,7 @@ Either follow the choice A. or B. below to run Observium.
 ```
 
 - Run this Observium container
-```
+```sh
   $ docker run --name observiumapp --link observiumdb:observiumdb \
     -v /home/docker/observium/logs:/opt/observium/logs \
     -v /home/docker/observium/rrd:/opt/observium/rrd \
@@ -37,41 +51,40 @@ Either follow the choice A. or B. below to run Observium.
     -e OBSERVIUM_DB_PASS=passw0rd \
     -e OBSERVIUM_DB_NAME=observium \
     -e OBSERVIUM_BASE_URL=http://yourserver.yourdomain:8080 \
-    -e TZ=Asia/Bangkok
+    -e TZ=$(cat /etc/timezone) \
     -p 8080:80
-    mbixtech/observium
+    mbixtech/observium:latest
 ```
 
 > Note:
 > - You must replace passwords specified in environment parameters of both containers with your secure passwords instead.
 > - Requires a linked MySQL or MariaDB container (ex.: `--link observiumdb:observiumdb`).
-> - OBSERVIUM_BASE_URL supports AMD64 container only (plan to support ARM32v7 soon).
+> - `OBSERVIUM_BASE_URL` supports AMD64 container only (plan to support ARM32v7 soon).
 
-
-### B. Use Docker Composer
-- Follow instuctions below to create extra working directory of docker containers (You can change /home/docker directory to your desired directory).
-```
+### B. Use Docker Compose
+- Follow instuctions below to create extra working directory of docker containers (You can change `/home/docker` directory to your desired directory).
+```sh
   $ cd /home/docker
   $ git clone https://github.com/somsakc/docker-observium.git observium
   $ cd observium
   $ mkdir data logs mysql
 ```
-> Note: You do not need to clone whole git repository. You can download docker-compose.yml file and .env file file. Then, place both files into e.g. /home/docker/observium directory mentioned above.
+> Note: You do not need to clone whole git repository. You can download `docker-compose.yml` file and `.env` file file. Then, place both files into e.g. `/home/docker/observium` directory mentioned above.
 
-- Change some environments to your appropreate values in docker-compose.yml file, e.g. OBSERVIUM_ADMIN_USER, OBSERVIUM_ADMIN_PASS.
+- Change some environments to your appropreate values in `docker-compose.yml` file, e.g. `OBSERVIUM_ADMIN_USER`, `OBSERVIUM_ADMIN_PASS`.
 
-- Force pulling the latest observium image from docker hub web site. It is to ensure that you will get the latest one.
-```
+- Force pulling the latest Observium image from docker hub web site. It is to ensure that you will get the latest one.
+```sh
   $ docker-compose pull
 ```
 
-- Run both database and observium containers.
-```
+- Run both database and Observium containers.
+```sh
   $ docker-compose up
 ```
 
 - For your first time, you may add a new device, discover and poll that device. It is given an idea below (I follow https://docs.observium.org/install_debian/#perform-initial-discovery-and-poll).
-```
+```sh
   $ docker-compose exec app /opt/observium/add_device.php <hostname> <community> v2c
   $ docker-compose exec app /opt/observium/discovery.php -h all
   $ docker-compose exec app /opt/observium/poller.php -h all

--- a/README.md
+++ b/README.md
@@ -75,19 +75,19 @@ Either follow the choice A. or B. below to run Observium.
 
 - Force pulling the latest Observium image from docker hub web site. It is to ensure that you will get the latest one.
 ```sh
-  $ docker-compose pull
+  $ docker compose pull
 ```
 
 - Run both database and Observium containers.
 ```sh
-  $ docker-compose up
+  $ docker compose up
 ```
 
 - For your first time, you may add a new device, discover and poll that device. It is given an idea below (I follow https://docs.observium.org/install_debian/#perform-initial-discovery-and-poll).
 ```sh
-  $ docker-compose exec app /opt/observium/add_device.php <hostname> <community> v2c
-  $ docker-compose exec app /opt/observium/discovery.php -h all
-  $ docker-compose exec app /opt/observium/poller.php -h all
+  $ docker compose exec app /opt/observium/add_device.php <hostname> <community> v2c
+  $ docker compose exec app /opt/observium/discovery.php -h all
+  $ docker compose exec app /opt/observium/poller.php -h all
 ```
 
 ## Changes

--- a/amd64/Dockerfile
+++ b/amd64/Dockerfile
@@ -30,7 +30,7 @@
 #  - Follow platform guideline specified in https://github.com/docker-library/official-images
 #
 
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
 ARG FETCH_VERSION=latest
 ARG OBSERVIUM_ADMIN_USER=admin
@@ -41,9 +41,9 @@ ARG OBSERVIUM_DB_PASS=passw0rd
 ARG OBSERVIUM_DB_NAME=observium
 
 LABEL maintainer "somsakc@hotmail.com"
-LABEL version="1.7"
-LABEL description="Docker container for Observium Community Edition"
-LABEL fetch_version="$FETCH_VERSION"
+LABEL version "1.8"
+LABEL description "Docker container for Observium Community Edition"
+LABEL fetch_version "$FETCH_VERSION"
 
 # set environment variables
 ENV FETCH_VERSION=$FETCH_VERSION
@@ -69,14 +69,15 @@ RUN apt update && \
                     wget
 
 # install observium required packages
-RUN apt install -y  libapache2-mod-php8.1 \
-                    php8.1-cli \
-                    php8.1-mysql \
-                    php8.1-gd \
-                    php8.1-bcmath \
-                    php8.1-mbstring \
-                    php8.1-opcache \
-                    php8.1-curl \
+RUN apt install -y  libapache2-mod-php \
+                    php-cli \
+                    php-mysql \
+                    php-gd \
+                    php-json \
+                    php-bcmath \
+                    php-mbstring \
+                    php-opcache \
+                    php-curl \
                     php-apcu \
                     php-pear \
                     libphp-phpmailer \
@@ -98,16 +99,16 @@ RUN apt install -y  libapache2-mod-php8.1 \
 
 # cleanup
 RUN apt clean && \
-    rm -f /etc/apache2/sites-available/* && \
-    rm -f /etc/cron.d/* && \
-    rm -f /etc/cron.hourly/* && \
-    rm -f /etc/cron.daily/* && \
-    rm -f /etc/cron.weekly/* && \
-    rm -f /etc/cron.monthly/* && \
-    rm -f /etc/logrotate.d/* && \
-    rm -f /etc/supervisord/conf.d/* && \
-    rm -fr /var/log/* && \
-    rm -fr /var/www && \
+    rm -f /etc/apache2/sites-available/* \
+       /etc/cron.d/* \
+       /etc/cron.hourly/* \
+       /etc/cron.daily/* \
+       /etc/cron.weekly/* \
+       /etc/cron.monthly/* \
+       /etc/logrotate.d/* \
+       /etc/supervisord/conf.d/* && \
+    rm -fr /var/log/* \
+       /var/www && \
     mkdir /var/log/apache2
 
 # set locale
@@ -139,7 +140,7 @@ RUN phpenmod mcrypt
 COPY observium-apache24 /etc/apache2/sites-available/000-default.conf
 RUN a2dismod mpm_event && \
     a2enmod mpm_prefork && \
-    a2enmod php8.1 && \
+    a2enmod php8.3 && \
     a2enmod rewrite && \
     chmod 644 /etc/apache2/sites-available/000-default.conf && \
     sed -i -e 's#${APACHE_LOG_DIR}/#/opt/observium/logs/apache2-#g' /etc/apache2/apache2.conf

--- a/amd64/docker-compose.yml
+++ b/amd64/docker-compose.yml
@@ -1,11 +1,9 @@
-# Docker compose file for Observium
+# Example Docker Compose file for Observium
 # Maintained by somsakc@hotmail.com
-
-version: '3'
 
 services:
   db:
-    image: mariadb:10.6.4
+    image: mariadb:11.6
     environment:
       - MYSQL_ROOT_PASSWORD=passw0rd
       - MYSQL_USER=observium
@@ -16,17 +14,17 @@ services:
       - ./data:/var/lib/mysql
     networks:
       - back-tier
-    restart: always
+    restart: unless-stopped
 
   app:
     # Launch published image.
-    image: mbixtech/observium:latest
+    image: tmp:latest # mbixtech/observium:latest
 
-    # Or build image.
+    # Or build image:
     # build:
     #   args:
     #     # Build specific version or "latest".
-    #     # - FETCH_VERSION=22.12
+    #     # - FETCH_VERSION=24.12
     #     - FETCH_VERSION=latest
 
     environment:
@@ -36,7 +34,7 @@ services:
       - OBSERVIUM_DB_NAME=observium
       - OBSERVIUM_DB_USER=observium
       - OBSERVIUM_DB_PASS=passw0rd
-      - OBSERVIUM_BASE_URL=http://observium.mbixtech.com:8888
+      - OBSERVIUM_BASE_URL=http://yourservername:8888
       - TZ=Asia/Bangkok
     volumes:
       - ./logs:/opt/observium/logs
@@ -45,7 +43,7 @@ services:
       - back-tier
     ports:
       - "8888:80"
-    restart: always
+    restart: unless-stopped
     depends_on:
       - db
 

--- a/arm32v7/docker-compose.yml
+++ b/arm32v7/docker-compose.yml
@@ -1,7 +1,5 @@
-# Docker compose file for Observium
+# Example Docker Compose file for Observium
 # Maintained by somsakc@hotmail.com
-
-version: '3'
 
 services:
   observiumdb:
@@ -16,17 +14,17 @@ services:
       - ./data:/var/lib/mysql
     networks:
       - back-tier
-    restart: always
+    restart: unless-stopped
 
   observiumap:
     # Launch published image.
     image: mbixtech/arm32v7-observium:latest
 
-    # Or build image.
+    # Or build image:
     # build:
     #   args:
     #     # Build specific version or "latest".
-    #     # - FETCH_VERSION=22.12
+    #     # - FETCH_VERSION=24.12
     #     - FETCH_VERSION=latest
 
     environment:
@@ -36,7 +34,7 @@ services:
       - OBSERVIUM_DB_NAME=observium
       - OBSERVIUM_DB_USER=observium
       - OBSERVIUM_DB_PASS=passw0rd
-      - OBSERVIUM_BASE_URL=http://observium-rpi.mbixtech.com:8888
+      - OBSERVIUM_BASE_URL=http://yourservername:8888
       - TZ=Asia/Bangkok
     volumes:
       - ./logs:/opt/observium/logs
@@ -45,7 +43,7 @@ services:
       - back-tier
     ports:
       - "8888:80"
-    restart: always
+    restart: unless-stopped
     depends_on:
       - observiumdb
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,9 @@
-# Docker compose file for Observium
+# Docker Compose file for Observium
 # Maintained by somsakc@hotmail.com
-
-version: '3'
 
 services:
   db:
-    image: mariadb:10.6.4
+    image: mariadb:11.7
     environment:
       - MYSQL_ROOT_PASSWORD=passw0rd
       - MYSQL_USER=observium
@@ -16,10 +14,10 @@ services:
       - ./data:/var/lib/mysql
     networks:
       - back-tier
-    restart: always
+    restart: unless-stopped
 
   app:
-    image: mbixtech/observium:21.10
+    image: mbixtech/observium:24.12
     environment:
       - OBSERVIUM_ADMIN_USER=admin
       - OBSERVIUM_ADMIN_PASS=passw0rd
@@ -36,7 +34,7 @@ services:
       - back-tier
     ports:
       - "8888:80"
-    restart: always
+    restart: unless-stopped
     depends_on:
       - db
 


### PR DESCRIPTION
- Update amd64 Dockerfile.
  - Run on latest Ubuntu 24.04 image.
  - Supports running latest Observium 24.12.
- Update `docker-compose.yml` for recommended best practices.
- Update README.md with build image instructions.