### PR TITLE
Fix env variable & Run observium-init.sh before spawning supervisord

### DIFF
--- a/amd64/Dockerfile
+++ b/amd64/Dockerfile
@@ -156,7 +156,8 @@ WORKDIR /opt/observium
 
 # configure entry point
 COPY supervisord.conf /etc/supervisord.conf
-ENTRYPOINT [ "/usr/bin/supervisord", "-c", "/etc/supervisord.conf" ]
+COPY entrypoint.sh /
+ENTRYPOINT [ "/entrypoint.sh" ]
 
 # expose tcp port
 EXPOSE 80/tcp

--- a/amd64/entrypoint.sh
+++ b/amd64/entrypoint.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+/opt/observium/observium-init.sh && \
+	/usr/bin/supervisord -c /etc/supervisord.conf
+

--- a/amd64/observium-init.sh
+++ b/amd64/observium-init.sh
@@ -5,6 +5,10 @@ function WriteLog() {
   return 0
 }
 
+function escape() {
+  printf '%s' "${1}" | sed 's/[^[:alnum:]]/\\&/g'
+}
+
 # dynamically enforce timezone in container
 if [ -n "${TZ}" ]; then
    WriteLog "Set timezone to '${TZ}'"
@@ -46,13 +50,13 @@ WriteLog "Add admin user"
 # create a reusable environment for cronjobs
 WriteLog "Build environment script for cronjobs"
 (
-   echo "export OBSERVIUM_ADMIN_USER=${OBSERVIUM_ADMIN_USER}"
-   echo "export OBSERVIUM_ADMIN_PASS=${OBSERVIUM_ADMIN_PASS}"
-   echo "export OBSERVIUM_DB_HOST=${OBSERVIUM_DB_HOST}"
-   echo "export OBSERVIUM_DB_USER=${OBSERVIUM_DB_USER}"
-   echo "export OBSERVIUM_DB_PASS=${OBSERVIUM_DB_PASS}"
-   echo "export OBSERVIUM_DB_NAME=${OBSERVIUM_DB_NAME}"
-   echo "export OBSERVIUM_BASE_URL=${OBSERVIUM_BASE_URL}"
+  echo "export OBSERVIUM_ADMIN_USER="$(escape "${OBSERVIUM_ADMIN_USER}")""
+  echo "export OBSERVIUM_ADMIN_PASS="$(escape "${OBSERVIUM_ADMIN_PASS}")""
+  echo "export OBSERVIUM_DB_HOST="$(escape "${OBSERVIUM_DB_HOST}")""
+  echo "export OBSERVIUM_DB_USER="$(escape "${OBSERVIUM_DB_USER}")""
+  echo "export OBSERVIUM_DB_PASS="$(escape "${OBSERVIUM_DB_PASS}")""
+  echo "export OBSERVIUM_DB_NAME="$(escape "${OBSERVIUM_DB_NAME}")""
+  echo "export OBSERVIUM_BASE_URL="$(escape "${OBSERVIUM_BASE_URL}")""
 ) > "/opt/observium/observium-setenv.sh"
 chmod 750 "/opt/observium/observium-setenv.sh"
 

--- a/amd64/supervisord.conf
+++ b/amd64/supervisord.conf
@@ -27,10 +27,3 @@ stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
 user=root
 
-[program:init]
-command=/bin/bash -c "/opt/observium/observium-init.sh"
-stdout_logfile=/dev/stdout
-stdout_logfile_maxbytes=0
-stderr_logfile=/dev/stderr
-stderr_logfile_maxbytes=0
-user=root

--- a/arm32v7/Dockerfile
+++ b/arm32v7/Dockerfile
@@ -120,7 +120,8 @@ WORKDIR /opt/observium
 
 # configure entry point
 COPY supervisord.conf /etc/supervisord.conf
-ENTRYPOINT [ "/usr/bin/supervisord", "-c", "/etc/supervisord.conf" ]
+COPY entrypoint.sh /
+ENTRYPOINT [ "/entrypoint.sh" ]
 
 # expose tcp port
 EXPOSE 80/tcp

--- a/arm32v7/entrypoint.sh
+++ b/arm32v7/entrypoint.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+/opt/observium/observium-init.sh && \
+	/usr/bin/supervisord -c /etc/supervisord.conf
+

--- a/arm32v7/observium-init.sh
+++ b/arm32v7/observium-init.sh
@@ -12,14 +12,14 @@ while [ $rc -ne 0 ]
 do
    let count++
    echo "[$count] Verifying coonection to observium database."
-   mysql -h $OBSERVIUM_DB_HOST -u $OBSERVIUM_DB_USER --password=$OBSERVIUM_DB_PASS -e "select 1" $OBSERVIUM_DB_NAME >/dev/null
+   mysql -h "${OBSERVIUM_DB_HOST}" -u "${OBSERVIUM_DB_USER}" --password="${OBSERVIUM_DB_PASS}" -e "select 1" "${OBSERVIUM_DB_NAME}" >/dev/null
    rc=$?
    [ $rc -ne 0 ] && sleep 5
 done
 
 echo "Connected to observium database successfully."
 
-tables=`mysql -h $OBSERVIUM_DB_HOST -u $OBSERVIUM_DB_USER --password=$OBSERVIUM_DB_PASS -e "show tables" $OBSERVIUM_DB_NAME 2>/dev/null`
+tables=`mysql -h "${OBSERVIUM_DB_HOST}" -u "${OBSERVIUM_DB_USER}" --password="${OBSERVIUM_DB_PASS}" -e "show tables" "${OBSERVIUM_DB_NAME}" 2>/dev/null`
 
 if [ -z "$tables" ]
 then
@@ -27,7 +27,7 @@ then
    chown -v www-data:www-data /opt/observium/rrd
    echo "Initializing database schema in first time running for observium."
    /opt/observium/discovery.php -u
-   /opt/observium/adduser.php $OBSERVIUM_ADMIN_USER $OBSERVIUM_ADMIN_PASS 10
+   /opt/observium/adduser.php "${OBSERVIUM_ADMIN_USER}" "${OBSERVIUM_ADMIN_PASS}" 10
 else
   echo "Database schema initialization has been done already."
   sleep 5

--- a/arm32v7/observium-init.sh
+++ b/arm32v7/observium-init.sh
@@ -3,6 +3,11 @@
 count=0
 rc=1
 
+function escape() {
+  printf '%s' "${1}" | sed 's/[^[:alnum:]]/\\&/g'
+}
+
+
 while [ $rc -ne 0 ]
 do
    let count++
@@ -28,11 +33,11 @@ else
   sleep 5
 fi
 
-echo "export OBSERVIUM_ADMIN_USER=$OBSERVIUM_ADMIN_USER" >> /opt/observium/observium-setenv.sh
-echo "export OBSERVIUM_ADMIN_PASS=$OBSERVIUM_ADMIN_PASS" >> /opt/observium/observium-setenv.sh
-echo "export OBSERVIUM_DB_HOST=$OBSERVIUM_DB_HOST" >> /opt/observium/observium-setenv.sh
-echo "export OBSERVIUM_DB_USER=$OBSERVIUM_DB_USER" >> /opt/observium/observium-setenv.sh
-echo "export OBSERVIUM_DB_PASS=$OBSERVIUM_DB_PASS" >> /opt/observium/observium-setenv.sh
-echo "export OBSERVIUM_DB_NAME=$OBSERVIUM_DB_NAME" >> /opt/observium/observium-setenv.sh
+echo "export OBSERVIUM_ADMIN_USER="$(escape "${OBSERVIUM_ADMIN_USER}")"" >> /opt/observium/observium-setenv.sh
+echo "export OBSERVIUM_ADMIN_PASS="$(escape "${OBSERVIUM_ADMIN_PASS}")"" >> /opt/observium/observium-setenv.sh
+echo "export OBSERVIUM_DB_HOST="$(escape "${OBSERVIUM_DB_HOST}")"" >> /opt/observium/observium-setenv.sh
+echo "export OBSERVIUM_DB_USER="$(escape "${OBSERVIUM_DB_USER}")"" >> /opt/observium/observium-setenv.sh
+echo "export OBSERVIUM_DB_PASS="$(escape "${OBSERVIUM_DB_PASS}")"" >> /opt/observium/observium-setenv.sh
+echo "export OBSERVIUM_DB_NAME="$(escape "${OBSERVIUM_DB_NAME}")"" >> /opt/observium/observium-setenv.sh
 
 exit 0

--- a/arm32v7/supervisord.conf
+++ b/arm32v7/supervisord.conf
@@ -26,10 +26,3 @@ stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
 user=root
 
-[program:init]
-command=/bin/bash -c "/opt/observium/observium-init.sh"
-stdout_logfile=/dev/stdout
-stdout_logfile_maxbytes=0
-stderr_logfile=/dev/stderr
-stderr_logfile_maxbytes=0
-user=root


### PR DESCRIPTION
Hello,

This PR resolves two issues:

- Put `OBSERVIUM_*` environment variables in quotes to prevent special bash characters from being interpreted.
- Make sure that `observium-init.sh` is run before starting `supervisord`. This avoids log errors during container startup and prevents race conditions if observium starts before observium-init.sh has finished.

I've made the changes for both amd64 and arm32, but I only tested on amd64. I guess this should work on arm32 as well.

Feel free to let me know if I need to adjust or change anything in this PR.